### PR TITLE
feat: Add #getMethod to authFlow

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,9 @@ Auth verification data:
 - For Push: No data needed, the auth is verified by accepting the push notification on your
 cell phone; you can omit this step but it is provided as a noop so you can write uniform code.
 
+### authFlow.getMethod()
+Returns the method associated with current auth flow; it might be sms, otp or push.
+
 ### Enrollment
 
 #### enrollment.getAvailableMethods()

--- a/lib/transaction/auth_verification_step.js
+++ b/lib/transaction/auth_verification_step.js
@@ -19,6 +19,15 @@ function authVerificationStep(strategy, options) {
 
 authVerificationStep.prototype = object.create(EventEmitter.prototype);
 
+/**
+ * Returns method associated with current auth flow
+ *
+ * @returns {sms|otp|push}
+ */
+authVerificationStep.prototype.getMethod = function getMethod() {
+  return this.strategy.method;
+};
+
 authVerificationStep.prototype.verify = function verify(data) {
   var self = this;
 

--- a/test/transaction/auth_verification_step.test.js
+++ b/test/transaction/auth_verification_step.test.js
@@ -67,6 +67,12 @@ describe('transaction/auth_verificatin_step', function () {
       });
     });
 
+    describe('#getMethod', function () {
+      it('returns sms', function () {
+        expect(step.getMethod()).to.equal('sms');
+      });
+    });
+
     describe('#verify', function () {
       describe('when otpCode is not provided', function () {
         it('emits FieldRequiredError', function (done) {
@@ -178,6 +184,12 @@ describe('transaction/auth_verificatin_step', function () {
       });
     });
 
+    describe('#getMethod', function () {
+      it('returns otp', function () {
+        expect(step.getMethod()).to.equal('otp');
+      });
+    });
+
     describe('#verify', function () {
       describe('when otpCode is not provided', function () {
         it('emits FieldRequiredError', function (done) {
@@ -286,6 +298,12 @@ describe('transaction/auth_verificatin_step', function () {
         enrolledTransaction,
         loginCompleteHub: enrolledTransaction.loginCompleteHub,
         loginRejectedHub: enrolledTransaction.loginRejectedHub
+      });
+    });
+
+    describe('#getMethod', function () {
+      it('returns push', function () {
+        expect(step.getMethod()).to.equal('push');
       });
     });
 


### PR DESCRIPTION
It is a convenience method so you can avoid having to
record the method otherway or rely on the private strategy.
