### PR TITLE
doc: Add account name to issuer label documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ var auth0GuardianJS = require('auth0-guardian-js')({
 	requestToken: "{{ requestToken }}",
 
 	issuer: {
-		label: "{{ userData.friendlyUserId }}",
+		label: "{{ userData.friendlyUserId }}:{{ userData.email }}",
 		name: "{{ userData.tenant }}",
 	}
 });

--- a/example/basic_widget.html
+++ b/example/basic_widget.html
@@ -221,7 +221,7 @@
           requestToken: "{{ requestToken }}",
 
           issuer: {
-            label: "{{ userData.friendlyUserId }}",
+            label: "{{ userData.friendlyUserId }}:{{ userData.email }}",
             name: "{{ userData.tenant }}",
           }
         });


### PR DESCRIPTION
If issuer label is constructed in another way the visualization on phones is not optimum 
