### PR TITLE
fix: add stack to errors

### DIFF
--- a/lib/errors/guardian_error.js
+++ b/lib/errors/guardian_error.js
@@ -9,7 +9,7 @@ var codeMap = {
 };
 
 function GuardianError(payload) {
-  Error.call(this, payload.message);
+  var superError = Error.call(this, payload.message);
 
   if (codeMap[payload.errorCode]) {
     this.errorCode = codeMap[payload.errorCode];
@@ -18,7 +18,13 @@ function GuardianError(payload) {
   }
 
   this.statusCode = payload.statusCode;
-  this.stack = (payload.cause && payload.cause.stack) || this.stack;
+
+  if (payload.cause && payload.cause.stack) {
+    this.stack = payload.cause.stack;
+  } else {
+    this.stack = superError.stack;
+  }
+
   this.message = payload.message;
 }
 

--- a/test/transaction/auth_verification_step.test.js
+++ b/test/transaction/auth_verification_step.test.js
@@ -78,6 +78,7 @@ describe('transaction/auth_verificatin_step', function () {
         it('emits FieldRequiredError', function (done) {
           step.on('error', function (err) {
             expect(err).to.exist;
+            expect(err.stack).to.exist;
             expect(err).to.have.property('errorCode', 'field_required');
             expect(err).to.have.property('field', 'otpCode');
             done();
@@ -91,6 +92,7 @@ describe('transaction/auth_verificatin_step', function () {
         it('emits OTPValidationError', function (done) {
           step.on('error', function (err) {
             expect(err).to.exist;
+            expect(err.stack).to.exist;
             expect(err).to.have.property('errorCode', 'invalid_otp_format');
             done();
           });
@@ -132,6 +134,7 @@ describe('transaction/auth_verificatin_step', function () {
           it('emits that error', function (done) {
             step.on('error', function (err) {
               expect(err).to.exist;
+              expect(err.stack).to.exist;
               expect(err).to.have.property('errorCode', 'invalid_otp');
               expect(err).to.have.property('message', 'Invalid otp');
               expect(err).to.have.property('statusCode', 401);
@@ -195,6 +198,7 @@ describe('transaction/auth_verificatin_step', function () {
         it('emits FieldRequiredError', function (done) {
           step.on('error', function (err) {
             expect(err).to.exist;
+            expect(err.stack).to.exist;
             expect(err).to.have.property('errorCode', 'field_required');
             expect(err).to.have.property('field', 'otpCode');
             done();
@@ -208,6 +212,7 @@ describe('transaction/auth_verificatin_step', function () {
         it('emits OTPValidationError', function (done) {
           step.on('error', function (err) {
             expect(err).to.exist;
+            expect(err.stack).to.exist;
             expect(err).to.have.property('errorCode', 'invalid_otp_format');
             done();
           });
@@ -249,6 +254,7 @@ describe('transaction/auth_verificatin_step', function () {
           it('emits that error', function (done) {
             step.on('error', function (err) {
               expect(err).to.exist;
+              expect(err.stack).to.exist;
               expect(err).to.have.property('errorCode', 'invalid_otp');
               expect(err).to.have.property('message', 'Invalid otp');
               expect(err).to.have.property('statusCode', 401);

--- a/test/transaction/enrollment_confirmation_step.test.js
+++ b/test/transaction/enrollment_confirmation_step.test.js
@@ -92,6 +92,7 @@ describe('transaction/auth_verificatin_step', function () {
         it('emits FieldRequiredError', function (done) {
           step.on('error', function (err) {
             expect(err).to.exist;
+            expect(err.stack).to.exist;
             expect(err).to.have.property('errorCode', 'field_required');
             expect(err).to.have.property('field', 'otpCode');
             done();
@@ -105,6 +106,7 @@ describe('transaction/auth_verificatin_step', function () {
         it('emits OTPValidationError', function (done) {
           step.on('error', function (err) {
             expect(err).to.exist;
+            expect(err.stack).to.exist;
             expect(err).to.have.property('errorCode', 'invalid_otp_format');
             done();
           });
@@ -146,6 +148,7 @@ describe('transaction/auth_verificatin_step', function () {
           it('emits that error', function (done) {
             step.on('error', function (err) {
               expect(err).to.exist;
+              expect(err.stack).to.exist;
               expect(err).to.have.property('errorCode', 'invalid_otp');
               expect(err).to.have.property('message', 'Invalid otp');
               expect(err).to.have.property('statusCode', 401);
@@ -228,6 +231,7 @@ describe('transaction/auth_verificatin_step', function () {
         it('emits FieldRequiredError', function (done) {
           step.on('error', function (err) {
             expect(err).to.exist;
+            expect(err.stack).to.exist;
             expect(err).to.have.property('errorCode', 'field_required');
             expect(err).to.have.property('field', 'otpCode');
             done();
@@ -241,6 +245,7 @@ describe('transaction/auth_verificatin_step', function () {
         it('emits OTPValidationError', function (done) {
           step.on('error', function (err) {
             expect(err).to.exist;
+            expect(err.stack).to.exist;
             expect(err).to.have.property('errorCode', 'invalid_otp_format');
             done();
           });
@@ -282,6 +287,7 @@ describe('transaction/auth_verificatin_step', function () {
           it('emits that error', function (done) {
             step.on('error', function (err) {
               expect(err).to.exist;
+              expect(err.stack).to.exist;
               expect(err).to.have.property('errorCode', 'invalid_otp');
               expect(err).to.have.property('message', 'Invalid otp');
               expect(err).to.have.property('statusCode', 401);

--- a/test/transaction/index.test.js
+++ b/test/transaction/index.test.js
@@ -403,6 +403,7 @@ describe('transaction/index', function () {
           it('callbacks with FieldRequiredError', function (done) {
             notEnrolledTransaction.enroll('sms', { phoneNumber: '' }, function (err) {
               expect(err).to.exist;
+              expect(err.stack).to.exist;
               expect(err).to.have.property('errorCode', 'field_required');
               expect(err).to.have.property('field', 'phoneNumber');
               done();


### PR DESCRIPTION
The stack is not being added on chrome using common
apply on constructor strategy.