### PR TITLE
Fix QR

### DIFF
--- a/lib/enrollment_strategies/otp_enrollment_strategy.js
+++ b/lib/enrollment_strategies/otp_enrollment_strategy.js
@@ -69,7 +69,7 @@ authenticatorEnrollmentStrategy.prototype.getUri = function getUri() {
 
 authenticatorEnrollmentStrategy.prototype.getData = function getData() {
   return {
-    issuerLabel: this.enrollmentAttempt.getIssuerLabel(),
+    issuerName: this.enrollmentAttempt.getIssuerName(),
     otpSecret: this.enrollmentAttempt.getOtpSecret(),
     accountLabel: this.enrollmentAttempt.getAccountLabel()
   };

--- a/lib/utils/enrollment_uri_helper.js
+++ b/lib/utils/enrollment_uri_helper.js
@@ -53,9 +53,9 @@ module.exports = function enrollmentUriHelper(data) {
 
   var pathname;
   if (data.accountLabel) {
-    pathname = encodeURIComponent(data.issuerLabel + ':' + data.accountLabel);
+    pathname = encodeURIComponent(data.issuerName) + ':' + encodeURIComponent(data.accountLabel);
   } else {
-    pathname = encodeURIComponent(data.issuerLabel);
+    pathname = encodeURIComponent(data.issuerName);
   }
 
   return url.format({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-guardian-js",
-  "version": "0.2.5",
+  "version": "0.2.4",
   "description": "Interface",
   "main": "index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-guardian-js",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Interface",
   "main": "index.js",
   "directories": {

--- a/test/transaction/enrollment_confirmation_step.test.js
+++ b/test/transaction/enrollment_confirmation_step.test.js
@@ -196,7 +196,7 @@ describe('transaction/auth_verificatin_step', function () {
       strategy = botpEnrollmentStrategy({
         transactionToken,
         enrollmentAttempt: {
-          getIssuerLabel: sinon.stub().returns('Awesome tenant'),
+          getIssuerName: sinon.stub().returns('awesome-tenant'),
           getOtpSecret: sinon.stub().returns('ABC123456'),
           getAccountLabel: sinon.stub().returns('Account Label')
         }
@@ -214,14 +214,14 @@ describe('transaction/auth_verificatin_step', function () {
 
     describe('#getUri', function () {
       it('returns otp url', function () {
-        expect(step.getUri()).to.equal('otpauth://totp/Awesome%20tenant%3AAccount%20Label?secret=ABC123456');
+        expect(step.getUri()).to.equal('otpauth://totp/awesome-tenant:Account%20Label?secret=ABC123456&issuer=awesome-tenant');
       });
     });
 
     describe('#getData', function () {
       it('returns data that allows enrollment', function () {
         expect(step.getData()).to.eql({
-          issuerLabel: 'Awesome tenant',
+          issuerName: 'awesome-tenant',
           otpSecret: 'ABC123456',
           accountLabel: 'Account Label'
         });
@@ -354,7 +354,7 @@ describe('transaction/auth_verificatin_step', function () {
 
     describe('#getUri', function () {
       it('returns guardian url', function () {
-        expect(step.getUri()).to.equal('otpauth://totp/Awesome%20tenant%3AAccount%20Label?secret=ABC123456&' +
+        expect(step.getUri()).to.equal('otpauth://totp/tenant:Account%20Label?secret=ABC123456&' +
           'enrollment_tx_id=1234567&issuer=tenant&id=123456&' +
           'base_url=https%3A%2F%2Fme.too&algorithm=sha1&digits=6&counter=0&period=30');
       });

--- a/test/utils/enrollment_uri_helper.test.js
+++ b/test/utils/enrollment_uri_helper.test.js
@@ -17,7 +17,7 @@ describe('utils/enrollment_uri_helper', function () {
         digits: 6,
         counter: 0,
         period: 30
-      })).to.equal(['otpauth://totp/issuer%20label',
+      })).to.equal(['otpauth://totp/issuer%20name',
         '?secret=superSecret',
         '&enrollment_tx_id=aa1%20234',
         '&issuer=issuer%20name',
@@ -44,7 +44,7 @@ describe('utils/enrollment_uri_helper', function () {
         digits: 6,
         counter: 0,
         period: 30
-      })).to.equal(['otpauth://totp/issuer%20label%3Amyuser%40gmail.com',
+      })).to.equal(['otpauth://totp/issuer%20name:myuser%40gmail.com',
         '?secret=superSecret',
         '&enrollment_tx_id=aa1%20234',
         '&issuer=issuer%20name',
@@ -60,9 +60,9 @@ describe('utils/enrollment_uri_helper', function () {
   describe('when only issuer label and otp secret is specified', function () {
     it('returns the correct url', function () {
       expect(enrollmentUriHelper({
-        issuerLabel: 'issuer label',
+        issuerName: 'issuer name',
         otpSecret: 'superSecret'
-      })).to.equal('otpauth://totp/issuer%20label?secret=superSecret');
+      })).to.equal('otpauth://totp/issuer%20name?secret=superSecret&issuer=issuer%20name');
     });
   });
 });


### PR DESCRIPTION
Fix qr code for guardian; use issuer name instead of issuer label +
decode the ":"