### PR TITLE
Adding serialize and resume to guardianJs transactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,13 +293,13 @@ auth0GuardianJS.start(function(err, transaction) {
 });
 ```
 ### auth0GuardianJS.resume(options, transactionState, callback) 
-This continues a transaction saved by `transaction.serialize()`. The option parameter provides 
-the final user the opportunity to specify which kind of `transport` to use. That been:
+This continues a transaction saved by `transaction.serialize()`. The options parameter provides 
+the library user the opportunity to specify which kind of `transport` to use. Options include:
 
 - `socket`: a socket.io transport
-- `pooling`: a pooling transport.
+- `polling`: a polling transport.
 
-The default one is `socket`. 
+If not set, the `socket` transport is used as default
 
 This is a factory method, you SHOULD NOT instantiate`auth0GuardianJS`.
 
@@ -316,7 +316,7 @@ Later, in another part of the code:
 ```js
 var serializedTransaction = secureStorage.get('guardiantx');
 
-auth0GuardianJS.resume({ transport: 'pooling' }, serializedTransaction, function(err, transaction) {
+auth0GuardianJS.resume({ transport: 'polling' }, serializedTransaction, function(err, transaction) {
   //... continue using that transaction object.
 });
 
@@ -419,8 +419,8 @@ transaction.recover({ recoveryCode: recoveryCode });
 ```
 
 #### transaction.serialize() 
-The .serialize() method creates a plain javascript Object that should remind opaque 
-to the final user. This must be stored by the user in a secure way.
+The .serialize() method creates a plain javascript Object that should remain opaque 
+to the library user. This must be stored by the user in a secure way.
 
 This object is used in combination with `auth0GuardianJS.resume` 
 

--- a/README.md
+++ b/README.md
@@ -292,6 +292,35 @@ auth0GuardianJS.start(function(err, transaction) {
   //...
 });
 ```
+### auth0GuardianJS.resume(options, transactionState, callback) 
+This continues a transaction saved by `transaction.serialize()`. The option parameter provides 
+the final user the opportunity to specify which kind of `transport` to use. That been:
+
+- `socket`: a socket.io transport
+- `pooling`: a pooling transport.
+
+The default one is `socket`. 
+
+This is a factory method, you SHOULD NOT instantiate`auth0GuardianJS`.
+
+at some point in your code you stored the transaction:
+```js
+auth0GuardianJS.start(function(err, transaction) {
+  //...
+
+  secureStorage.store('guardiantx', transaction.serialize());
+});
+```
+
+Later, in another part of the code:
+```js
+var serializedTransaction = secureStorage.get('guardiantx');
+
+auth0GuardianJS.resume({ transport: 'pooling' }, serializedTransaction, function(err, transaction) {
+  //... continue using that transaction object.
+});
+
+```
 
 ### Transaction
 
@@ -388,6 +417,12 @@ recovery code is the new recovery code you must show to the user from him to sav
 ```js
 transaction.recover({ recoveryCode: recoveryCode });
 ```
+
+#### transaction.serialize() 
+The .serialize() method creates a plain javascript Object that should remind opaque 
+to the final user. This must be stored by the user in a secure way.
+
+This object is used in combination with `auth0GuardianJS.resume` 
 
 #### transaction.on(eventName, handler)
 Listen for `eventName` and execute the handler if that event is received. The

--- a/lib/entities/enrollment.js
+++ b/lib/entities/enrollment.js
@@ -48,4 +48,11 @@ enrollment.prototype.getPhoneNumber = function getPhoneNumber() {
   return this.data.phoneNumber;
 };
 
+/**
+ * @returns @see constructor.
+ */
+enrollment.prototype.serialize = function serialize() {
+  return this.data;
+};
+
 module.exports = enrollment;

--- a/lib/entities/enrollment_attempt.js
+++ b/lib/entities/enrollment_attempt.js
@@ -14,13 +14,15 @@ var object = require('../utils/object');
  * @param {string} data.baseUrl
  * @param {string} data.enrollmentId
  *
+ * @param {boolean} active
+ *
  * @private
  */
-function enrollmentAttempt(data) {
+function enrollmentAttempt(data, active) {
   var self = object.create(enrollmentAttempt.prototype);
 
   self.data = data;
-  self.active = false;
+  self.active = active || false;
 
   return self;
 }
@@ -108,6 +110,18 @@ enrollmentAttempt.prototype.setActive = function setActive(active) {
  */
 enrollmentAttempt.prototype.isActive = function isActive() {
   return this.active;
+};
+
+/**
+ * @public
+ *
+ * @returns {{data: *, active: *}} @see constructor
+ */
+enrollmentAttempt.prototype.serialize = function serialize() {
+  return {
+    data: this.data,
+    active: this.active
+  };
 };
 
 module.exports = enrollmentAttempt;

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,13 +6,9 @@ var errors = require('./errors');
 var object = require('./utils/object');
 var jwtToken = require('./utils/jwt_token');
 var auth0Ticket = require('./utils/auth0_ticket');
-var enrollment = require('./entities/enrollment');
 var httpClient = require('./utils/http_client');
-var transaction = require('./transaction');
-var socketClient = require('./utils/socket_client');
-var pollingClient = require('./utils/polling_client');
-var enrollmentAttempt = require('./entities/enrollment_attempt');
-
+var transactionFactory = require('./transaction/factory');
+var clientFactory = require('./utils/client_factory');
 /**
  * @public
  *
@@ -32,8 +28,8 @@ var enrollmentAttempt = require('./entities/enrollment_attempt');
  * @param {string} options.accountLabel
  * @param {socket|polling} [options.transport]
  *
- * @param {SocketClient} [dependencies.socketClient] Client factory for socket api
- * @param {function(serviceUrl)} [dependencies.httpClient] Client factory for http
+ * @param {SocketClient} [options.dependencies.socketClient] Client factory for socket api
+ * @param {function(serviceUrl)} [options.dependencies.httpClient] Client factory for http
  */
 function auth0GuardianJS(options) {
   var self = object.create(auth0GuardianJS.prototype);
@@ -48,16 +44,14 @@ function auth0GuardianJS(options) {
   self.httpClient = object.get(options, 'dependencies.httpClient',
     httpClient(self.serviceUrl, globalTrackingId));
 
-  self.socketClient = object.get(options, 'dependencies.socketClient');
   self.transport = options.transport || 'socket';
 
-  if (!self.socketClient) {
-    if (options.transport === 'polling') {
-      self.socketClient = pollingClient(self.serviceUrl, { httpClient: self.httpClient });
-    } else {
-      self.socketClient = socketClient(self.serviceUrl);
-    }
-  }
+  self.socketClient = clientFactory.create({
+    serviceUrl: self.serviceUrl,
+    transport: self.transport,
+    httpClient: self.httpClient,
+    dependency: object.get(options, 'dependencies.socketClient')
+  });
 
   return self;
 }
@@ -105,7 +99,7 @@ auth0GuardianJS.prototype.start = function start(callback) {
 
           var tx;
           try {
-            tx = buildTransaction({
+            tx = transactionFactory.fromStartFlow({
               transactionToken: transactionToken,
               txLegacyData: txLegacyData,
               issuer: self.issuer,
@@ -128,6 +122,70 @@ auth0GuardianJS.prototype.start = function start(callback) {
 /**
  * @public
  *
+ * This takes a parameter what transaction.serialize returns to
+ * resume the transaction with auth0-mfa-api
+ *
+ * @param {string} transactionState.transactionToken
+ *
+ * @param {undefined|Object} transactionState.enrollmentAttempt
+ * @param {Object} transactionState.enrollmentAttempt.data - @see enrollmentAttempt
+ * @param {boolean} transactionState.enrollmentAttempt.active
+ *
+ * @param {object[]} transactionState.enrollments - @see enrollment
+
+ * @param {object} transactionState.availableEnrollmentMethods
+ * @param {object} transactionState.availableAuthenticationMethods
+ *
+ * @param {string} transactionState.baseUrl
+
+ * @param {undefined|string} options.transport
+ * @param {SocketClient} [options.dependencies.socketClient] Client factory for socket api
+ * @param {function(serviceUrl)} [options.dependencies.httpClient] Client factory for http
+ */
+
+auth0GuardianJS.resume = function resume(options, transactionState, callback) {
+  var txId = jwtToken(transactionState.transactionToken).getDecoded().txid;
+
+  // create httpClient/socketClient
+  var httpClientInstance = object.get(options, 'dependencies.httpClient',
+    httpClient(transactionState.baseUrl, txId));
+
+  var transport = options.transport || 'socket';
+
+  var socketClient = clientFactory.create({
+    serviceUrl: transactionState.baseUrl,
+    transport: transport,
+    httpClient: httpClientInstance,
+    dependency: object.get(options, 'dependencies.socketClient')
+  });
+
+  // connect
+  socketClient.connect(transactionState.transactionToken,
+    function onSocketConnection(connectErr) {
+      if (connectErr) {
+        callback(connectErr);
+        return;
+      }
+      var tx;
+
+      try {
+        tx = transactionFactory.fromTransactionState(transactionState, {
+          transactionEventsReceiver: socketClient,
+          httpClient: httpClientInstance
+        });
+      } catch (transactionBuildingErr) {
+        callback(transactionBuildingErr);
+        return;
+      }
+
+      callback(null, tx);
+    });
+};
+
+
+/**
+ * @public
+ *
  * Post result to url using an standard form
  *
  * @param {string} url url to post
@@ -137,42 +195,6 @@ auth0GuardianJS.formPostHelper = function formPostHelper(url, obj) {
   form({ document: global.document }).post(url, obj);
 };
 
-function buildTransaction(data, options) {
-  var txLegacyData = data.txLegacyData;
-  var issuer = data.issuer;
-  var serviceUrl = data.serviceUrl;
-  var accountLabel = data.accountLabel;
-  var transactionToken = data.transactionToken;
-  var txData = {};
-
-
-  txData.transactionToken = transactionToken;
-  txData.availableEnrollmentMethods = txLegacyData.availableEnrollmentMethods;
-  txData.availableAuthenticationMethods = txLegacyData.availableAuthenticationMethods;
-
-  if (txLegacyData.enrollmentTxId) {
-    txData.enrollmentAttempt = enrollmentAttempt({
-      enrollmentId: txLegacyData.deviceAccount.id,
-      enrollmentTxId: txLegacyData.enrollmentTxId,
-      otpSecret: txLegacyData.deviceAccount.otpSecret,
-      recoveryCode: txLegacyData.deviceAccount.recoveryCode,
-      issuer: issuer,
-      baseUrl: serviceUrl,
-      accountLabel: accountLabel
-    });
-  } else {
-    var defaultEnrollment = enrollment({
-      methods: txLegacyData.deviceAccount.methods,
-      availableMethods: txLegacyData.deviceAccount.availableMethods,
-      name: txLegacyData.deviceAccount.name,
-      phoneNumber: txLegacyData.deviceAccount.phoneNumber
-    });
-
-    txData.enrollments = [defaultEnrollment];
-  }
-
-  return transaction(txData, options);
-}
 
 module.exports = auth0GuardianJS;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -122,8 +122,8 @@ auth0GuardianJS.prototype.start = function start(callback) {
 /**
  * @public
  *
- * This takes a parameter what transaction.serialize returns to
- * resume the transaction with auth0-mfa-api
+ * Takes a parameter returned from transaction.serialize to resume the transaction
+ * with auth0-mfa-api
  *
  * @param {string} transactionState.transactionToken
  *
@@ -186,7 +186,7 @@ auth0GuardianJS.resume = function resume(options, transactionState, callback) {
 /**
  * @public
  *
- * Post result to url using an standard form
+ * Post result to url using a standard form
  *
  * @param {string} url url to post
  * @param {object} obj result with signature to post

--- a/lib/transaction/factory.js
+++ b/lib/transaction/factory.js
@@ -52,7 +52,8 @@ exports.fromStartFlow = function buildTransactionFromStartFlow(data, options) {
  * @param {object} transactionState.availableAuthenticationMethods
  *
  * @param {EventEmitter} options.transactionEventsReceiver
- *  Receiver for transaction events; it will receive  backend related transaction events
+ * Receiver for transaction events; it will receive  backend related transaction events
+ *
  * @param {HttpClient} options.HttpClient
  *
  * @returns {Transaction}

--- a/lib/transaction/factory.js
+++ b/lib/transaction/factory.js
@@ -1,0 +1,76 @@
+var enrollmentAttempt = require('../entities/enrollment_attempt');
+var enrollment = require('../entities/enrollment');
+var transaction = require('./');
+var jwtToken = require('../utils/jwt_token');
+var object = require('../utils/object');
+
+exports.fromStartFlow = function buildTransactionFromStartFlow(data, options) {
+  var txLegacyData = data.txLegacyData;
+  var issuer = data.issuer;
+  var serviceUrl = data.serviceUrl;
+  var accountLabel = data.accountLabel;
+  var transactionToken = data.transactionToken;
+  var txData = {};
+
+  txData.transactionToken = transactionToken;
+  txData.availableEnrollmentMethods = txLegacyData.availableEnrollmentMethods;
+  txData.availableAuthenticationMethods = txLegacyData.availableAuthenticationMethods;
+
+  if (txLegacyData.enrollmentTxId) {
+    txData.enrollmentAttempt = enrollmentAttempt({
+      enrollmentId: txLegacyData.deviceAccount.id,
+      enrollmentTxId: txLegacyData.enrollmentTxId,
+      otpSecret: txLegacyData.deviceAccount.otpSecret,
+      recoveryCode: txLegacyData.deviceAccount.recoveryCode,
+      issuer: issuer,
+      baseUrl: serviceUrl,
+      accountLabel: accountLabel
+    });
+  } else {
+    var defaultEnrollment = enrollment({
+      methods: txLegacyData.deviceAccount.methods,
+      availableMethods: txLegacyData.deviceAccount.availableMethods,
+      name: txLegacyData.deviceAccount.name,
+      phoneNumber: txLegacyData.deviceAccount.phoneNumber
+    });
+
+    txData.enrollments = [defaultEnrollment];
+  }
+
+  return transaction(txData, options);
+};
+/**
+ * @param {string} transactionState.transactionToken
+ *
+ * @param {undefined|Object} transactionState.enrollmentAttempt
+ * @param {Object} transactionState.enrollmentAttempt.data - @see enrollmentAttempt
+ * @param {boolean} transactionState.enrollmentAttempt.active
+ *
+ * @param {object[]} transactionState.enrollments - @see enrollment
+
+ * @param {object} transactionState.availableEnrollmentMethods
+ * @param {object} transactionState.availableAuthenticationMethods
+ *
+ * @param {EventEmitter} options.transactionEventsReceiver
+ *  Receiver for transaction events; it will receive  backend related transaction events
+ * @param {HttpClient} options.HttpClient
+ *
+ * @returns {Transaction}
+ */
+exports.fromTransactionState = function fromTransactionState(transactionState, options) {
+  var txData = {
+    transactionToken: jwtToken(transactionState.transactionToken),
+    enrollments: object.map(transactionState.enrollments, enrollment),
+    availableEnrollmentMethods: transactionState.availableEnrollmentMethods,
+    availableAuthenticationMethods: transactionState.availableAuthenticationMethods
+  };
+
+  if (transactionState.enrollmentAttempt) {
+    txData.enrollmentAttempt = enrollmentAttempt(
+      transactionState.enrollmentAttempt.data,
+      transactionState.enrollmentAttempt.active
+    );
+  }
+
+  return transaction(txData, options);
+};

--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -138,6 +138,31 @@ function transaction(data, options) {
 
 transaction.prototype = object.create(EventEmitter.prototype);
 
+/**
+ * @Public
+ *
+ * This methods return an object that represents the the inner state of the transaction. Is useful
+ * to store some where this state and resume this transaction later.
+ *
+ * @returns {Object}
+ *
+ */
+transaction.prototype.serialize = function serialize() {
+  function enrollmentSerialize(enrollment) {
+    return enrollment.serialize();
+  }
+
+  return {
+    transactionToken: this.transactionToken.getToken(),
+    enrollmentAttempt: this.enrollmentAttempt ? this.enrollmentAttempt.serialize() : undefined,
+    enrollments: object.map(this.enrollments, enrollmentSerialize),
+    baseUrl: this.httpClient.getBaseUrl(),
+    availableEnrollmentMethods: this.availableEnrollmentMethods,
+    availableAuthenticationMethods: this.availableAuthenticationMethods
+  };
+};
+
+
 transaction.prototype.getState = function getState(callback) {
   var self = this;
 

--- a/lib/utils/client_factory.js
+++ b/lib/utils/client_factory.js
@@ -1,0 +1,20 @@
+var pooling = require('./polling_client');
+var socketio = require('./socket_client');
+
+exports.create = function create(options) {
+  var serviceUrl = options.serviceUrl;
+  var transport = options.transport;
+  var httpClient = options.httpClient;
+  var dependency = options.dependency;
+
+  if (dependency) {
+    return dependency;
+  }
+
+  if (transport === 'polling') {
+    return pooling(serviceUrl, { httpClient: httpClient });
+  }
+
+  // default socket
+  return socketio(serviceUrl);
+};

--- a/lib/utils/client_factory.js
+++ b/lib/utils/client_factory.js
@@ -1,4 +1,4 @@
-var pooling = require('./polling_client');
+var polling = require('./polling_client');
 var socketio = require('./socket_client');
 
 exports.create = function create(options) {
@@ -12,7 +12,7 @@ exports.create = function create(options) {
   }
 
   if (transport === 'polling') {
-    return pooling(serviceUrl, { httpClient: httpClient });
+    return polling(serviceUrl, { httpClient: httpClient });
   }
 
   // default socket

--- a/lib/utils/http_client.js
+++ b/lib/utils/http_client.js
@@ -25,6 +25,9 @@ function httpClient(baseUrl, globalTrackingId) {
 
   return self;
 }
+httpClient.prototype.getBaseUrl = function getBaseUrl() {
+  return this.baseUrl;
+};
 
 httpClient.prototype.get = function get(path, credentials, options, callback) {
   this.request('get', path, credentials, null, options, callback);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -309,4 +309,53 @@ describe('guardian.js', function () {
       });
     });
   });
+
+  describe('#resume', function () {
+    // eslint-disable-next-line
+    const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE0NzgyMTU4OTUwMDAwMDAsInR4aWQiOiIyYTliNWI2YjQzYjFiNmIyYjkiLCJhZG1pbiI6dHJ1ZX0.E5-_n8sdEyZ1RuDUdMJr9JSJB0AuE4ODMyVGIrG8Jg8';
+    const serializedTransaction = {
+      transactionToken: token,
+      enrollments: [
+        {
+          availableMethods: ['sms'],
+          phoneNumber: '+1111111'
+        }
+      ],
+      baseUrl: 'http://42.org',
+      availableEnrollmentMethods: ['sms'],
+      availableAuthenticationMethods: ['push']
+    };
+
+    httpClient = {
+      post: sinon.stub(),
+      get: sinon.stub(),
+      put: sinon.stub(),
+      patch: sinon.stub(),
+      del: sinon.stub()
+    };
+
+    socketClient = {
+      connect: sinon.stub(),
+      on: sinon.stub()
+    };
+
+    const options = { dependencies: { httpClient, socketClient } };
+
+    socketClient.connect.yields();
+
+    it('callbacks with a enrolled transaction', function (done) {
+      guardianjsb.resume(options, serializedTransaction, (err, tx) => {
+        expect(err).not.to.exist;
+
+        const enrollment = tx.getEnrollments()[0];
+        expect(enrollment.getPhoneNumber()).to.equal('+1111111');
+        expect(enrollment.getAvailableMethods()).to.eql(['sms']);
+
+        expect(tx.getAvailableEnrollmentMethods()).to.eql(['sms']);
+        expect(tx.getAvailableAuthenticationMethods()).to.eql(['push']);
+
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
- new factory for `client` (websocket/pooling)
- new factory for `transaction` (fromStartFlow/fromTransactionState)
- new `.serialize` method on Transaction
- new `.resume` method in guardianJS to continue from a seralized transaction. 