### PR TITLE
Update socket.io and superagent to fix low level issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,3 +38,10 @@
 
 **Added**
 - Allow a callback onto .recover method [\#30](https://github.com/auth0/auth0-guardian.js/pull/31) ([dafortune](https://github.com/dafortune)).
+
+
+# [v1.1.1](https://github.com/auth0/auth0-guardian.js/tree/v1.1.1) (2017-06-13)
+[Full Changelog](https://github.com/auth0/auth0-guardian.js/compare/v1.1.1...v1.1.0)
+
+**Fix**
+- Bump dependencies versions (no breaking changes) [\#37](https://github.com/auth0/auth0-guardian.js/pull/37) ([dafortune](https://github.com/dafortune)).

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "jwt-decode": "^2.2.0",
-    "socket.io-client": "^1.7.2",
+    "socket.io-client": "^2.0.3",
     "superagent": "^3.5.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "dependencies": {
     "jwt-decode": "^2.2.0",
-    "socket.io-client": "^1.5.0",
-    "superagent": "^2.3.0"
+    "socket.io-client": "^1.7.2",
+    "superagent": "^3.5.1"
   },
   "devDependencies": {
     "auth0-style": "github:auth0/javascript",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-guardian-js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Interface",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Updated socket.io and superagent; none of the breaking changes affect us.

The vulnerabilities were not really accessible from guardian.js code paths,
however it is better to keep the code clean of security issues.

The update includes a major bump in both libraries however I checked that none of the changes
affected us (history.md) and also tested all the flows manually and automated (functional tests)
