### PR TITLE
Handle errors on basic widget example

### DIFF
--- a/example/basic_widget.html
+++ b/example/basic_widget.html
@@ -65,7 +65,15 @@
         <button type="button" data-saved-recovery>Got it!</button>
       </div>
 
-      <div data-loading data-screen>Loading...</div>
+      {% if errors %}
+      <ul>
+          {% for error in errors %}
+        <li>{{ error.message }} ({{ error.code }})</li>
+          {% endfor %}
+      </ul>
+      {% else %}
+      <div data-loading data-screen>{{errors}}Loading...</div>
+      {% endif %}
 
       <div class="hidden" data-screen data-enrollment-enroll data-method="sms">
         <div data-enrollment-toolbar>


### PR DESCRIPTION
When the template fails to render because the request is invalid (e.g. invalid state) or the enrollment ticket is no valid, the example does not show any error, and instead leaves the `Loading...` indicator.

This PR adds a small block to display the error message and code so you can realize something went wrong when using the example.