### PR TITLE
Add `stateCheckingMechanism` to example.

### DIFF
--- a/example/basic_widget.html
+++ b/example/basic_widget.html
@@ -239,7 +239,10 @@
             name: "{{ userData.tenant }}",
           },
 
-          globalTrackingId: "{{ globalTrackingId }}"
+          globalTrackingId: "{{ globalTrackingId }}",
+          {% if stateCheckingMechanism %}
+            stateCheckingMechanism: "{{ stateCheckingMechanism }}",
+          {% endif %}
         });
 
         $root


### PR DESCRIPTION
Include `stateCheckingMechanism` option when configuring guardian.js.