### PR TITLE
Use 'polling' as the default state checking mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ the library user the opportunity to specify which kind of `transport` to use. Op
 - `socket`: a socket.io transport
 - `polling`: a polling transport.
 
-If not set, the `socket` transport is used as default
+If not set, the `polling` transport is used as default
 
 This is a factory method, you SHOULD NOT instantiate`auth0GuardianJS`.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -53,7 +53,7 @@ function auth0GuardianJS(options) {
   self.httpClient = object.get(options, 'dependencies.httpClient',
     httpClient(self.serviceUrl, globalTrackingId));
 
-  self.transport = options.transport || options.stateCheckingMechanism || 'socket';
+  self.transport = options.transport || options.stateCheckingMechanism || apiTransport.polling;
 
   self.socketClient = clientFactory.create({
     serviceUrl: self.serviceUrl,
@@ -173,7 +173,7 @@ auth0GuardianJS.resume = function resume(options, transactionState, callback) {
     var httpClientInstance = object.get(options, 'dependencies.httpClient',
       httpClient(transactionState.baseUrl, txId));
 
-    var transport = options.transport || options.stateCheckingMechanism || 'socket';
+    var transport = options.transport || options.stateCheckingMechanism || apiTransport.polling;
 
     if (transactionTokenObject.isExpired()) {
       asyncHelpers.setImmediate(callback, new errors.CredentialsExpiredError());

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -229,7 +229,7 @@ describe('guardian.js', function () {
             const call = httpClient.post.getCall(0);
             expect(call.args[0]).to.equal('/api/start-flow');
             expect(call.args[1].getAuthHeader()).to.equal(`Bearer ${requestToken}`);
-            expect(call.args[2]).to.eql({ state_transport: 'socket' });
+            expect(call.args[2]).to.eql({ state_transport: 'polling' });
 
             done();
           });


### PR DESCRIPTION
### Description

We are moving to polling as the default state checking mechanism in an attempt to reduce socket.io traffic from Guardian clients.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

There's an existing test checking for the default used for the state checking mechanism.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
