### PR TITLE
[MFA-2005] fix URL locality

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ https://cdn.auth0.com/js/guardian-js/1.3.3/guardian-js.min.js
 ```js
 var auth0GuardianJS = require('auth0-guardian-js')({
 	// For US tenants: https://{name}.guardian.auth0.com
- 	// For AU tenants: https://{name}.au.guardian.auth0.com
- 	// For EU tenants: https://{name}.eu.guardian.auth0.com
+ 	// For AU tenants: https://{name}.guardian.au.auth0.com
+ 	// For EU tenants: https://{name}.guardian.eu.auth0.com
 	serviceUrl: "https://{{ userData.tenant }}.guardian.auth0.com",
 	requestToken: "{{ requestToken }}", // or ticket: "{{ ticket }}" - see below
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,8 +22,8 @@ var apiTransport = {
  * @param {string} options.serviceUrl Service base url
  * @example `
  *  For US: https://{name}.guardian.auth0.com
- *  For AU: https://{name}.au.guardian.auth0.com
- *  For EU: https://{name}.eu.guardian.auth0.com
+ *  For AU: https://{name}.guardian.au.auth0.com
+ *  For EU: https://{name}.guardian.eu.auth0.com
  * `
  * @param {string} options.requestToken Request token got from auth0
  * @param {string} options.issuer.label User friendly label for the issuer to


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

Fix the locality of the URL in the examples.

The guardian URL template is `{tenant}.guardian.{locality}.auth0.com`
But the examples were `{tenant}.{locality}.guardian.auth0.com`


### References

[MFA-2005](https://auth0team.atlassian.net/browse/MFA-2005)

### Testing

View the readme

- [-] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [-] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch


[MFA-2005]: https://auth0team.atlassian.net/browse/MFA-2005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ