### PR TITLE
feat: MFA-4417 support configurable OTP length for phone factor

### DIFF
--- a/lib/auth_strategies/otp_auth_strategy.js
+++ b/lib/auth_strategies/otp_auth_strategy.js
@@ -7,6 +7,8 @@ var validations = require('../utils/validations');
 
 /**
  * @param {JWTToken} data.transactionToken
+ * @param {number} [data.otpLength] Expected number of digits for the OTP code.
+ *  Defaults to 6 when omitted.
  * @param {HttpClient} options.httpClient
  */
 function otpAuthenticatorStrategy(data, options) {
@@ -15,6 +17,7 @@ function otpAuthenticatorStrategy(data, options) {
   self.method = data.method || 'otp';
 
   self.transactionToken = data.transactionToken;
+  self.otpLength = data.otpLength;
   self.httpClient = options.httpClient;
 
   return self;
@@ -30,7 +33,7 @@ otpAuthenticatorStrategy.prototype.verify = function verify(data, callback) {
     return;
   }
 
-  if (!validations.validateOtp(data.otpCode)) {
+  if (!validations.validateOtp(data.otpCode, this.otpLength)) {
     asyncHelpers.setImmediate(callback, new errors.OTPValidationError());
     return;
   }

--- a/lib/auth_strategies/sms_auth_strategy.js
+++ b/lib/auth_strategies/sms_auth_strategy.js
@@ -5,6 +5,8 @@ var otpAuthenticatorStrategy = require('./otp_auth_strategy');
 
 /**
  * @param {JWTToken} data.transactionToken
+ * @param {number} [data.otpLength] Expected number of digits for the SMS/voice
+ *  OTP code. Defaults to 6 when omitted.
  * @param {HttpClient} options.httpClient
  */
 function smsAuthenticatorStrategy(data, options) {
@@ -17,7 +19,8 @@ function smsAuthenticatorStrategy(data, options) {
 
   self.otpAuthenticatorStrategy = otpAuthenticatorStrategy({
     transactionToken: data.transactionToken,
-    method: self.method
+    method: self.method,
+    otpLength: data.otpLength
   }, {
     httpClient: self.httpClient
   });

--- a/lib/enrollment_strategies/sms_enrollment_strategy.js
+++ b/lib/enrollment_strategies/sms_enrollment_strategy.js
@@ -10,6 +10,8 @@ var validations = require('../utils/validations');
  * @param {HttpClient} options.httpClient
  * @param {JWTToken} data.transactionToken
  * @param {EnrollmentAttempt} data.enrollmentAttempt
+ * @param {number} [data.otpLength] Expected number of digits for the SMS/voice
+ *  OTP code. Defaults to 6 when omitted.
  */
 function smsEnrollmentStrategy(data, options) {
   var self = object.create(smsEnrollmentStrategy.prototype);
@@ -17,6 +19,7 @@ function smsEnrollmentStrategy(data, options) {
   self.method = 'sms';
   self.enrollmentAttempt = data.enrollmentAttempt;
   self.transactionToken = data.transactionToken;
+  self.otpLength = data.otpLength;
   self.httpClient = options.httpClient;
 
   return self;
@@ -54,7 +57,7 @@ smsEnrollmentStrategy.prototype.confirm = function confirm(data, callback) {
     return;
   }
 
-  if (!validations.validateOtp(data.otpCode)) {
+  if (!validations.validateOtp(data.otpCode, this.otpLength)) {
     asyncHelpers.setImmediate(callback, new errors.OTPValidationError());
     return;
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,6 +33,8 @@ var apiTransport = {
  * @param {string} [options.globalTrackingId] Id used to associate the request
  * in the transaction (that includes both Guardian and Auth0-server requests)
  * @param {string} options.accountLabel
+ * @param {number} [options.otpLength] Expected number of digits for OTP codes
+ *  (SMS/voice). Defaults to 6 when omitted.
  *
  * @deprecated @param {string} [options.transport] Use stateCheckingMechanism
  * @param {string} [options.stateCheckingMechanism]
@@ -47,6 +49,7 @@ function auth0GuardianJS(options) {
   self.credentials = authFactory(options);
   self.issuer = options.issuer;
   self.accountLabel = options.accountLabel;
+  self.otpLength = options.otpLength;
 
   var globalTrackingId = options.globalTrackingId;
 
@@ -121,7 +124,8 @@ auth0GuardianJS.prototype.start = function start(callback) {
               txLegacyData: txLegacyData,
               issuer: self.issuer,
               serviceUrl: self.serviceUrl,
-              accountLabel: self.accountLabel
+              accountLabel: self.accountLabel,
+              otpLength: self.otpLength
             }, {
               transactionEventsReceiver: self.socketClient,
               httpClient: self.httpClient
@@ -199,7 +203,8 @@ auth0GuardianJS.resume = function resume(options, transactionState, callback) {
         try {
           tx = transactionFactory.fromTransactionState(transactionState, {
             transactionEventsReceiver: socketClient,
-            httpClient: httpClientInstance
+            httpClient: httpClientInstance,
+            otpLength: options.otpLength
           });
         } catch (transactionBuildingErr) {
           callback(transactionBuildingErr);

--- a/lib/transaction/factory.js
+++ b/lib/transaction/factory.js
@@ -15,6 +15,7 @@ exports.fromStartFlow = function buildTransactionFromStartFlow(data, options) {
   txData.transactionToken = transactionToken;
   txData.availableEnrollmentMethods = txLegacyData.availableEnrollmentMethods;
   txData.availableAuthenticationMethods = txLegacyData.availableAuthenticationMethods;
+  txData.otpLength = data.otpLength;
 
   if (txLegacyData.enrollmentTxId) {
     txData.enrollmentAttempt = enrollmentAttempt({
@@ -72,7 +73,8 @@ exports.fromTransactionState = function fromTransactionState(transactionState, o
     availableEnrollmentMethods: transactionState.availableEnrollmentMethods,
     availableAuthenticationMethods: transactionState.availableAuthenticationMethods,
     authVerificationStep: transactionState.authVerificationStep,
-    enrollmentConfirmationStep: transactionState.enrollmentConfirmationStep
+    enrollmentConfirmationStep: transactionState.enrollmentConfirmationStep,
+    otpLength: options.otpLength
   };
 
   if (transactionState.enrollmentAttempt) {

--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -61,16 +61,26 @@ function transaction(data, options) {
     transactionToken: data.transactionToken
   };
 
+  // The configurable OTP length applies to the phone factor only (SMS/voice).
+  // TOTP and recovery codes keep their fixed lengths.
+  var smsEnrollmentStrategyData = object.assign({}, enrollmentStrategyData, {
+    otpLength: data.otpLength
+  });
+
   self.enrollmentStrategies = {
-    sms: smsEnrollmentStrategy(enrollmentStrategyData, { httpClient: httpClient }),
+    sms: smsEnrollmentStrategy(smsEnrollmentStrategyData, { httpClient: httpClient }),
     push: pnEnrollmentStrategy(enrollmentStrategyData, { httpClient: httpClient }),
     otp: otpEnrollmentStrategy(enrollmentStrategyData, { httpClient: httpClient })
   };
 
   var authStrategiesData = { transactionToken: data.transactionToken };
 
+  var smsAuthStrategyData = object.assign({}, authStrategiesData, {
+    otpLength: data.otpLength
+  });
+
   self.authStrategies = {
-    sms: smsAuthStrategy(authStrategiesData, { httpClient: httpClient }),
+    sms: smsAuthStrategy(smsAuthStrategyData, { httpClient: httpClient }),
     push: pnAuthStrategy(authStrategiesData, { httpClient: httpClient }),
     otp: otpAuthStrategy(authStrategiesData, { httpClient: httpClient }),
     'recovery-code': authRecoveryStrategy(authStrategiesData, { httpClient: httpClient })

--- a/lib/utils/validations.js
+++ b/lib/utils/validations.js
@@ -9,15 +9,20 @@ var object = require('./object');
 var OTP_LENGTH = 6;
 var RECOVERY_CODE_LENGTH = 24;
 
+exports.DEFAULT_OTP_LENGTH = OTP_LENGTH;
+
 /**
  * @param {string} iotp One time password
+ * @param {number} [otpLength] Expected number of digits. Defaults to 6 to
+ *  preserve the historical behaviour for callers that don't supply a length.
  *
  * @returns {boolean} true if otp is a valid otp, false otherwise
  */
-exports.validateOtp = function validateOtp(iotp) {
+exports.validateOtp = function validateOtp(iotp, otpLength) {
   var otp = iotp && iotp.toString();
+  var expectedLength = typeof otpLength === 'number' ? otpLength : OTP_LENGTH;
 
-  return object.isIntegerString(otp) && otp.length === OTP_LENGTH;
+  return object.isIntegerString(otp) && otp.length === expectedLength;
 };
 
 /**

--- a/test/transaction/auth_verification_step.test.js
+++ b/test/transaction/auth_verification_step.test.js
@@ -192,6 +192,47 @@ describe('transaction/auth_verification_step', function () {
       });
     });
 
+    describe('#verify with a custom otpLength', function () {
+      beforeEach(function () {
+        const customLengthStrategy = bsmsAuthStrategy({
+          transactionToken,
+          otpLength: 8
+        }, {
+          httpClient
+        });
+
+        step = authVerificationStep(customLengthStrategy, {
+          enrolledTransaction,
+          loginCompleteHub: enrolledTransaction.loginCompleteHub,
+          loginRejectedHub: enrolledTransaction.loginRejectedHub
+        });
+      });
+
+      it('accepts an otp of the configured length', function (done) {
+        httpClient.post = function (path, credentials, data, callback) {
+          expect(path).to.equal('api/verify-otp');
+          expect(data).to.eql({
+            code: '12345678',
+            type: 'manual_input'
+          });
+
+          callback();
+          done();
+        };
+
+        step.verify({ otpCode: '12345678' });
+      });
+
+      it('rejects an otp that does not match the configured length', function (done) {
+        step.on('error', function (err) {
+          expect(err).to.have.property('errorCode', 'invalid_otp_format');
+          done();
+        });
+
+        step.verify({ otpCode: '123456' });
+      });
+    });
+
     callbackBasedVerificationExamples();
   });
 

--- a/test/transaction/enrollment_confirmation_step.test.js
+++ b/test/transaction/enrollment_confirmation_step.test.js
@@ -212,6 +212,49 @@ describe('transaction/auth_verificatin_step', function () {
       });
     });
 
+    describe('#confirm with a custom otpLength', function () {
+      beforeEach(function () {
+        const customLengthStrategy = bsmsEnrollmentStrategy({
+          transactionToken,
+          enrollmentAttempt: notEnrolledTransaction.enrollmentAttempt,
+          otpLength: 8
+        }, {
+          httpClient
+        });
+
+        step = enrollmentConfirmationStep({
+          strategy: customLengthStrategy,
+          transaction: notEnrolledTransaction,
+          enrollmentCompleteHub: notEnrolledTransaction.enrollmentCompleteHub,
+          enrollmentAttempt: notEnrolledTransaction.enrollmentAttempt
+        });
+      });
+
+      it('accepts an otp of the configured length', function (done) {
+        httpClient.post = function (path, credentials, data, callback) {
+          expect(path).to.equal('api/verify-otp');
+          expect(data).to.eql({
+            code: '12345678',
+            type: 'manual_input'
+          });
+
+          callback();
+          done();
+        };
+
+        step.confirm({ otpCode: '12345678' });
+      });
+
+      it('rejects an otp that does not match the configured length', function (done) {
+        step.on('error', function (err) {
+          expect(err).to.have.property('errorCode', 'invalid_otp_format');
+          done();
+        });
+
+        step.confirm({ otpCode: '123456' });
+      });
+    });
+
     callbackBasedEnrollmentConfirmation();
   });
 

--- a/test/utils/validations.test.js
+++ b/test/utils/validations.test.js
@@ -28,6 +28,31 @@ describe('utils/validations', function () {
         expect(validations.validateOtp('555556')).to.be.true;
       });
     });
+
+    describe('when an explicit otp length is provided', function () {
+      it('returns true when the otp matches the provided length', function () {
+        expect(validations.validateOtp('12345678', 8)).to.be.true;
+      });
+
+      it('returns false when the otp is shorter than the provided length', function () {
+        expect(validations.validateOtp('123456', 8)).to.be.false;
+      });
+
+      it('returns false when the otp is longer than the provided length', function () {
+        expect(validations.validateOtp('123456789', 8)).to.be.false;
+      });
+
+      it('returns false when the otp has letters', function () {
+        expect(validations.validateOtp('1234567a', 8)).to.be.false;
+      });
+    });
+
+    describe('when otp length is not a number', function () {
+      it('falls back to the default length of 6', function () {
+        expect(validations.validateOtp('555556', undefined)).to.be.true;
+        expect(validations.validateOtp('5555567', undefined)).to.be.false;
+      });
+    });
   });
 
   describe('#validateRecovery', function () {


### PR DESCRIPTION
## Summary

Make the OTP length configurable for the phone factor (SMS/voice) instead of hardcoding it to 6; enables the classic Guardian widget to honour a tenant's configured phone OTP length.

## Changes

- `lib/utils/validations.js` — `validateOtp(otp, otpLength)` now accepts an optional length. Defaults to `6` when omitted or non-numeric, so existing callers are unaffected. Exposes `DEFAULT_OTP_LENGTH`.
- `lib/index.js` — the public `auth0GuardianJS(options)` entry accepts `options.otpLength`, threaded into both `start` and `resume`.
- `lib/transaction/factory.js` + `lib/transaction/index.js` — carry `otpLength` into the transaction, applied **only** to the SMS auth and SMS enrollment strategies. TOTP/recovery codes keep their fixed lengths.
- `lib/auth_strategies/{sms,otp}_auth_strategy.js` and `lib/enrollment_strategies/sms_enrollment_strategy.js` — validate the OTP against the configured length.

## Backwards compatibility

Purely additive. `validateOtp(otp)` and `auth0GuardianJS({...})` called without a length behave exactly as before (length 6). No public signatures removed or reordered — only optional params added. Consumers opt in by passing `otpLength`; no coordination is required for existing integrations.

## Testing

- `npm test` (eslint + mocha): **245 passing** (+9 new), covering the validation primitive with explicit/omitted lengths, SMS auth verify, and SMS enrollment confirm.

## Notes

- ⚠️ **Standalone build:** `npm run build` currently fails to minify (`guardian-js.min.js`) because `socket.io-client@4.x` ships ES6 that the pinned UglifyJS (webpack 1.x) cannot parse. This is a pre-existing issue (introduced when socket.io-client was bumped from v2 to v4), **not** caused by this change, but it must be resolved before publishing a standalone release. Tracking separately.