### PR TITLE
feat: MFA-4417/MFA-4751 read configurable phone OTP length from the transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,19 @@
 # Change Log
+# [v1.4.0](https://github.com/auth0/auth0-guardian.js/tree/v1.4.0) (2026-06-30)
+[Full Changelog](https://github.com/auth0/auth0-guardian.js/compare/v1.3.3...v1.4.0)
+
+**Added**
+- Validate the phone (SMS/voice) OTP code against the OTP length advertised in the transaction start-flow response, instead of always assuming 6 digits. When the response does not include a length, validation falls back to 6, so existing integrations are unaffected. The expected length is persisted by `transaction.serialize()` and restored on resume.
+
+**Changed**
+- `validateOtp(otp, otpLength)` now accepts an optional expected length (defaults to 6) and exposes `DEFAULT_OTP_LENGTH`.
+
+# [v1.3.3](https://github.com/auth0/auth0-guardian.js/tree/v1.3.3) (2024-09-22)
+[Full Changelog](https://github.com/auth0/auth0-guardian.js/compare/v1.3.2...v1.3.3)
+
+**Fixed**
+- Bump dependency versions to reduce vulnerabilities (no breaking changes).
+
 # [v1.3.2](https://github.com/auth0/auth0-guardian.js/tree/v1.3.2) (2018-06-14)
 [Full Changelog](https://github.com/auth0/auth0-guardian.js/compare/v1.3.1...v1.3.2)
 

--- a/lib/auth_strategies/otp_auth_strategy.js
+++ b/lib/auth_strategies/otp_auth_strategy.js
@@ -7,6 +7,8 @@ var validations = require('../utils/validations');
 
 /**
  * @param {JWTToken} data.transactionToken
+ * @param {number} [data.otpLength] Expected number of digits for the OTP code.
+ *  Defaults to 6 when omitted.
  * @param {HttpClient} options.httpClient
  */
 function otpAuthenticatorStrategy(data, options) {
@@ -15,6 +17,7 @@ function otpAuthenticatorStrategy(data, options) {
   self.method = data.method || 'otp';
 
   self.transactionToken = data.transactionToken;
+  self.otpLength = data.otpLength;
   self.httpClient = options.httpClient;
 
   return self;
@@ -30,7 +33,7 @@ otpAuthenticatorStrategy.prototype.verify = function verify(data, callback) {
     return;
   }
 
-  if (!validations.validateOtp(data.otpCode)) {
+  if (!validations.validateOtp(data.otpCode, this.otpLength)) {
     asyncHelpers.setImmediate(callback, new errors.OTPValidationError());
     return;
   }

--- a/lib/auth_strategies/sms_auth_strategy.js
+++ b/lib/auth_strategies/sms_auth_strategy.js
@@ -5,6 +5,8 @@ var otpAuthenticatorStrategy = require('./otp_auth_strategy');
 
 /**
  * @param {JWTToken} data.transactionToken
+ * @param {number} [data.otpLength] Expected number of digits for the SMS/voice
+ *  OTP code. Defaults to 6 when omitted.
  * @param {HttpClient} options.httpClient
  */
 function smsAuthenticatorStrategy(data, options) {
@@ -17,7 +19,8 @@ function smsAuthenticatorStrategy(data, options) {
 
   self.otpAuthenticatorStrategy = otpAuthenticatorStrategy({
     transactionToken: data.transactionToken,
-    method: self.method
+    method: self.method,
+    otpLength: data.otpLength
   }, {
     httpClient: self.httpClient
   });

--- a/lib/enrollment_strategies/sms_enrollment_strategy.js
+++ b/lib/enrollment_strategies/sms_enrollment_strategy.js
@@ -10,6 +10,8 @@ var validations = require('../utils/validations');
  * @param {HttpClient} options.httpClient
  * @param {JWTToken} data.transactionToken
  * @param {EnrollmentAttempt} data.enrollmentAttempt
+ * @param {number} [data.otpLength] Expected number of digits for the SMS/voice
+ *  OTP code. Defaults to 6 when omitted.
  */
 function smsEnrollmentStrategy(data, options) {
   var self = object.create(smsEnrollmentStrategy.prototype);
@@ -17,6 +19,7 @@ function smsEnrollmentStrategy(data, options) {
   self.method = 'sms';
   self.enrollmentAttempt = data.enrollmentAttempt;
   self.transactionToken = data.transactionToken;
+  self.otpLength = data.otpLength;
   self.httpClient = options.httpClient;
 
   return self;
@@ -54,7 +57,7 @@ smsEnrollmentStrategy.prototype.confirm = function confirm(data, callback) {
     return;
   }
 
-  if (!validations.validateOtp(data.otpCode)) {
+  if (!validations.validateOtp(data.otpCode, this.otpLength)) {
     asyncHelpers.setImmediate(callback, new errors.OTPValidationError());
     return;
   }

--- a/lib/transaction/factory.js
+++ b/lib/transaction/factory.js
@@ -15,6 +15,13 @@ exports.fromStartFlow = function buildTransactionFromStartFlow(data, options) {
   txData.transactionToken = transactionToken;
   txData.availableEnrollmentMethods = txLegacyData.availableEnrollmentMethods;
   txData.availableAuthenticationMethods = txLegacyData.availableAuthenticationMethods;
+  // Tenant-configured OTP length for the phone factor (SMS/voice), exposed by
+  // mfa-api in the start-flow response under factor_settings.phone.otp_length.
+  // Absent for tenants/servers without Advanced Factor Configuration, in which
+  // case the SMS strategies fall back to the default length.
+  txData.phoneOtpLength = txLegacyData.factorSettings &&
+    txLegacyData.factorSettings.phone &&
+    txLegacyData.factorSettings.phone.otpLength;
 
   if (txLegacyData.enrollmentTxId) {
     txData.enrollmentAttempt = enrollmentAttempt({
@@ -71,6 +78,7 @@ exports.fromTransactionState = function fromTransactionState(transactionState, o
     enrollments: object.map(transactionState.enrollments, enrollment),
     availableEnrollmentMethods: transactionState.availableEnrollmentMethods,
     availableAuthenticationMethods: transactionState.availableAuthenticationMethods,
+    phoneOtpLength: transactionState.phoneOtpLength,
     authVerificationStep: transactionState.authVerificationStep,
     enrollmentConfirmationStep: transactionState.enrollmentConfirmationStep
   };

--- a/lib/transaction/index.js
+++ b/lib/transaction/index.js
@@ -61,16 +61,26 @@ function transaction(data, options) {
     transactionToken: data.transactionToken
   };
 
+  // The configurable OTP length applies to the phone factor only (SMS/voice).
+  // TOTP and recovery codes keep their fixed lengths.
+  var smsEnrollmentStrategyData = object.assign({}, enrollmentStrategyData, {
+    otpLength: data.phoneOtpLength
+  });
+
   self.enrollmentStrategies = {
-    sms: smsEnrollmentStrategy(enrollmentStrategyData, { httpClient: httpClient }),
+    sms: smsEnrollmentStrategy(smsEnrollmentStrategyData, { httpClient: httpClient }),
     push: pnEnrollmentStrategy(enrollmentStrategyData, { httpClient: httpClient }),
     otp: otpEnrollmentStrategy(enrollmentStrategyData, { httpClient: httpClient })
   };
 
   var authStrategiesData = { transactionToken: data.transactionToken };
 
+  var smsAuthStrategyData = object.assign({}, authStrategiesData, {
+    otpLength: data.phoneOtpLength
+  });
+
   self.authStrategies = {
-    sms: smsAuthStrategy(authStrategiesData, { httpClient: httpClient }),
+    sms: smsAuthStrategy(smsAuthStrategyData, { httpClient: httpClient }),
     push: pnAuthStrategy(authStrategiesData, { httpClient: httpClient }),
     otp: otpAuthStrategy(authStrategiesData, { httpClient: httpClient }),
     'recovery-code': authRecoveryStrategy(authStrategiesData, { httpClient: httpClient })
@@ -86,6 +96,7 @@ function transaction(data, options) {
   self.transactionEventsReceiver = options.transactionEventsReceiver;
   self.availableEnrollmentMethods = data.availableEnrollmentMethods;
   self.availableAuthenticationMethods = data.availableAuthenticationMethods;
+  self.phoneOtpLength = data.phoneOtpLength;
 
   self.loginCompleteHub = eventListenerHub(
     self.transactionEventsReceiver, 'login:complete');
@@ -237,7 +248,8 @@ transaction.prototype.serialize = function serialize() {
     transactionToken: this.transactionToken.getToken(),
     baseUrl: this.httpClient.getBaseUrl(),
     availableEnrollmentMethods: this.availableEnrollmentMethods,
-    availableAuthenticationMethods: this.availableAuthenticationMethods
+    availableAuthenticationMethods: this.availableAuthenticationMethods,
+    phoneOtpLength: this.phoneOtpLength
   };
 
   data.enrollments = object.map(this.enrollments, enrollmentSerialize);

--- a/lib/utils/validations.js
+++ b/lib/utils/validations.js
@@ -9,15 +9,20 @@ var object = require('./object');
 var OTP_LENGTH = 6;
 var RECOVERY_CODE_LENGTH = 24;
 
+exports.DEFAULT_OTP_LENGTH = OTP_LENGTH;
+
 /**
  * @param {string} iotp One time password
+ * @param {number} [otpLength] Expected number of digits. Defaults to 6 to
+ *  preserve the historical behaviour for callers that don't supply a length.
  *
  * @returns {boolean} true if otp is a valid otp, false otherwise
  */
-exports.validateOtp = function validateOtp(iotp) {
+exports.validateOtp = function validateOtp(iotp, otpLength) {
   var otp = iotp && iotp.toString();
+  var expectedLength = typeof otpLength === 'number' ? otpLength : OTP_LENGTH;
 
-  return object.isIntegerString(otp) && otp.length === OTP_LENGTH;
+  return object.isIntegerString(otp) && otp.length === expectedLength;
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-guardian-js",
-  "version": "1.3.3",
+  "version": "1.4.0",
   "description": "Interface",
   "main": "index.js",
   "directories": {

--- a/test/transaction/factory.test.js
+++ b/test/transaction/factory.test.js
@@ -68,6 +68,23 @@ describe('transaction/factory phone otp length (factor_settings)', function () {
         });
       });
     });
+
+    it('threads the length into the SMS enrollment strategy so it validates that digit count', function (done) {
+      const tx = buildStartFlow(buildTxLegacyData({
+        factorSettings: { phone: { otpLength: 7 } }
+      }));
+
+      // confirm() validates the code length before posting; a 6-digit code is
+      // rejected and a 7-digit one is accepted, mirroring the auth strategy.
+      tx.enrollmentStrategies.sms.confirm({ otpCode: '123456' }, function (sixErr) {
+        expect(sixErr).to.be.an.instanceof(errors.OTPValidationError);
+
+        tx.enrollmentStrategies.sms.confirm({ otpCode: '1234567' }, function (sevenErr) {
+          expect(sevenErr).to.equal(null);
+          done();
+        });
+      });
+    });
   });
 
   describe('when factor_settings is absent (older mfa-api / flag off)', function () {

--- a/test/transaction/factory.test.js
+++ b/test/transaction/factory.test.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const EventEmitter = require('events').EventEmitter;
+const transactionFactory = require('../../lib/transaction/factory');
+const jwtToken = require('../../lib/utils/jwt_token');
+const errors = require('../../lib/errors');
+
+// eslint-disable-next-line
+const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjI5NTY0MzE2MjksInR4aWQiOiJ0eF8xMjM0NSIsImFkbWluIjp0cnVlfQ.KYkrYwJJg-QuG1IVtCs7q7y-532t50xk3f8jIXcmsJc';
+
+describe('transaction/factory phone otp length (factor_settings)', function () {
+  let httpClient;
+  let options;
+
+  beforeEach(function () {
+    httpClient = {
+      post: sinon.stub().yields(null, {}),
+      get: sinon.stub(),
+      getBaseUrl: sinon.stub().returns('https://tenant.guardian.auth0.com')
+    };
+    options = { httpClient, transactionEventsReceiver: new EventEmitter() };
+  });
+
+  // Builds the camelCased start-flow payload as the httpClient delivers it,
+  // for an already-enrolled (authentication) transaction.
+  function buildTxLegacyData(extra) {
+    return Object.assign({
+      transactionToken: token,
+      availableEnrollmentMethods: ['sms'],
+      availableAuthenticationMethods: ['sms'],
+      deviceAccount: {
+        methods: ['sms'],
+        availableMethods: ['sms'],
+        availableAuthenticatorTypes: ['sms'],
+        name: 'device',
+        phoneNumber: '+1111111'
+      }
+    }, extra);
+  }
+
+  // The factory's fromStartFlow takes { transactionToken, txLegacyData, ... }.
+  function buildStartFlow(txLegacyData) {
+    return transactionFactory.fromStartFlow({
+      transactionToken: jwtToken(token),
+      txLegacyData: txLegacyData,
+      issuer: { label: 'tenant', name: 'tenant' },
+      serviceUrl: 'https://tenant.guardian.auth0.com',
+      accountLabel: 'user@example.com'
+    }, options);
+  }
+
+  describe('when factor_settings.phone.otp_length is present (camelCased to factorSettings.phone.otpLength)', function () {
+    it('threads the length into the SMS auth strategy so it validates that digit count', function (done) {
+      const tx = buildStartFlow(buildTxLegacyData({
+        factorSettings: { phone: { otpLength: 7 } }
+      }));
+
+      // A 7-digit code must be accepted (posted to verify-otp), a 6-digit one rejected.
+      tx.authStrategies.sms.verify({ otpCode: '123456' }, function (sixErr) {
+        expect(sixErr).to.be.an.instanceof(errors.OTPValidationError);
+
+        tx.authStrategies.sms.verify({ otpCode: '1234567' }, function (sevenErr) {
+          expect(sevenErr).to.equal(null);
+          sinon.assert.calledWithMatch(httpClient.post, 'api/verify-otp');
+          done();
+        });
+      });
+    });
+  });
+
+  describe('when factor_settings is absent (older mfa-api / flag off)', function () {
+    it('falls back to the default length of 6', function (done) {
+      const tx = buildStartFlow(buildTxLegacyData());
+
+      tx.authStrategies.sms.verify({ otpCode: '1234567' }, function (sevenErr) {
+        expect(sevenErr).to.be.an.instanceof(errors.OTPValidationError);
+
+        tx.authStrategies.sms.verify({ otpCode: '123456' }, function (sixErr) {
+          expect(sixErr).to.equal(null);
+          done();
+        });
+      });
+    });
+  });
+
+  describe('serialize / fromTransactionState round-trip', function () {
+    it('preserves phoneOtpLength so a resumed transaction validates the same length', function (done) {
+      const tx = buildStartFlow(buildTxLegacyData({
+        factorSettings: { phone: { otpLength: 7 } }
+      }));
+
+      const state = tx.serialize();
+      expect(state.phoneOtpLength).to.equal(7);
+
+      const resumed = transactionFactory.fromTransactionState(state, options);
+      resumed.authStrategies.sms.verify({ otpCode: '123456' }, function (sixErr) {
+        expect(sixErr).to.be.an.instanceof(errors.OTPValidationError);
+        done();
+      });
+    });
+  });
+});

--- a/test/utils/validations.test.js
+++ b/test/utils/validations.test.js
@@ -28,6 +28,29 @@ describe('utils/validations', function () {
         expect(validations.validateOtp('555556')).to.be.true;
       });
     });
+
+    describe('when an explicit otpLength is provided', function () {
+      it('accepts an otp matching the configured length', function () {
+        expect(validations.validateOtp('1234567', 7)).to.be.true;
+      });
+
+      it('rejects an otp shorter than the configured length', function () {
+        expect(validations.validateOtp('123456', 7)).to.be.false;
+      });
+
+      it('rejects an otp longer than the configured length', function () {
+        expect(validations.validateOtp('12345678', 7)).to.be.false;
+      });
+
+      it('falls back to the default length of 6 when otpLength is not a number', function () {
+        expect(validations.validateOtp('123456', undefined)).to.be.true;
+        expect(validations.validateOtp('1234567', undefined)).to.be.false;
+      });
+
+      it('exposes DEFAULT_OTP_LENGTH as 6', function () {
+        expect(validations.DEFAULT_OTP_LENGTH).to.equal(6);
+      });
+    });
   });
 
   describe('#validateRecovery', function () {


### PR DESCRIPTION
## Summary

Make the phone factor (SMS/voice) OTP length configurable instead of hardcoding it to 6, sourcing the length from the transaction start-flow response. The library self-sources the length from the transaction it already fetches — the hosting application passes nothing, and the public API (`auth0GuardianJS(options)`) is unchanged.

## Changes

- `lib/utils/validations.js` — `validateOtp(otp, otpLength)` (an internal helper, not part of the public API) accepts an optional expected length, defaulting to `6` when omitted or non-numeric. Exposes `DEFAULT_OTP_LENGTH`.
- `lib/transaction/factory.js` — reads the length from the start-flow response at `factorSettings.phone.otpLength` and carries it into the transaction; restores it from serialized state in `fromTransactionState`.
- `lib/transaction/index.js` — applies the length **only** to the SMS auth and SMS enrollment strategies (TOTP and recovery codes keep their fixed lengths), and persists it in `serialize()` so resumed transactions validate the same length.
- `lib/auth_strategies/{sms,otp}_auth_strategy.js` and `lib/enrollment_strategies/sms_enrollment_strategy.js` — validate the OTP against the configured length.

## Public API

No change. The package entry (`auth0GuardianJS`) takes no new option and exposes no new method; `validateOtp` is an internal helper not reachable from the public surface. The configured length flows in entirely from the mfa-api start-flow response, so the library never asks the embedder to provide it.

## Backwards compatibility

Purely additive. When the start-flow response does not include `factorSettings.phone.otpLength`, the SMS strategies fall back to length 6 — existing behaviour is unchanged. `validateOtp(otp)` called without a length behaves exactly as before. No public signatures removed or reordered.

## Testing

- `npm test` (mocha): **245 passing** (+9 new), covering the validation primitive with explicit/omitted lengths and a transaction-factory suite that asserts the length is threaded into the SMS auth **and** enrollment strategies, falls back to 6 when absent, and survives a `serialize` / `fromTransactionState` round-trip.

## Notes

- ⚠️ **Standalone build:** `npm run build` currently fails to minify (`guardian-js.min.js`) because `socket.io-client@4.x` ships ES6 that the pinned UglifyJS (webpack 1.x) cannot parse. Pre-existing (introduced when socket.io-client was bumped v2→v4), **not** caused by this change, but must be resolved before publishing a standalone release. Tracking separately.
- Supersedes #95 (which passed the length as a widget/constructor input).
